### PR TITLE
Add options for geometry and location

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ Fuzzy.nvim provides a simple mechanism and pipeline to create fuzzy matching in 
 - LspReferences
 - LspWorkspaceSymbols
 - LspDocumentSymbols
+
+# Options
+- You can set window location and geometry using the `g:fuzzy_options` variable :
+  - location can be `center`, `bottom` or a function with `win_width`(width of the floating window) and`win_height`(height of the floating window) as arguments returning the location of the NE corner of the floating window
+  - Width and height are in percent of the main window
+```lua
+lua << EOF
+  vim.g.fuzzy_options = {
+    location = "center",
+    width = 50,
+    height = 50
+  }
+EOF
+```

--- a/lua/fuzzy/drawer.lua
+++ b/lua/fuzzy/drawer.lua
@@ -29,8 +29,8 @@ function M.new()
   vim.cmd [[ startinsert! ]]
  
   -- Check for options
+  -- should be set as vim.g.fuzzy_options = {location = "center", width = 50, height = 50}
   local options = vim.g.fuzzy_options or {}
-  local loc = location.bottom_center
   if options.location then
     -- loc can be "center", "bottom" or a function
     if options.location == 'center' then

--- a/lua/fuzzy/drawer.lua
+++ b/lua/fuzzy/drawer.lua
@@ -28,7 +28,29 @@ function M.new()
  
   vim.cmd [[ startinsert! ]]
  
-  local buf, win, closer = floating.floating_buffer(math.ceil(vim.api.nvim_get_option('columns')/2), math.ceil(vim.api.nvim_get_option('lines')), location.bottom_center)
+  -- Check for options
+  local options = vim.g.fuzzy_options or {}
+  local loc = location.bottom_center
+  if options.location then
+    -- loc can be "center", "bottom" or a function
+    if options.location == 'center' then
+      loc = location.center
+    elseif options.location == 'bottom' then
+      loc = location.bottom_center
+    end
+  end
+  -- Width and height should be proportions (percentages) of the main window
+  local win_width = math.ceil(vim.api.nvim_get_option('columns')/2)
+  local win_height = math.ceil(vim.api.nvim_get_option('lines'))
+  if options.width then
+    local width = options.width
+    win_width = math.ceil(vim.api.nvim_get_option('columns')*width/100)
+  end
+  if options.height then
+    local height = options.height
+    win_height = math.ceil(vim.api.nvim_get_option('lines')*height/100)
+  end
+  local buf, win, closer = floating.floating_buffer(win_width, win_height, loc)
 
   vim.api.nvim_buf_set_keymap(buf, 'i', '<C-p>', '<cmd> lua CURRENT_FUZZY.drawer:selection_up()<CR>', {})
   vim.api.nvim_buf_set_keymap(buf, 'i', '<C-k>', '<cmd> lua CURRENT_FUZZY.drawer:selection_up()<CR>', {})


### PR DESCRIPTION
This adds the usage of the global `fuzzy_options` global variable for options. This is of the form
````lua
vim.g.fuzzy_options = {
  location = "center|bottom",
  width = 50, -- percentage of the main window 
  height = 50 -- percentage of the main window
}